### PR TITLE
feat: benchmark Docker registry mirror pull speed

### DIFF
--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -56,7 +56,7 @@ jobs:
           test -f results/v1/$RUN_NAME.csv || echo "time,docker mirror pull mean (s),docker mirror pull min (s),docker mirror pull max (s)," > results/v1/$RUN_NAME.csv
 
       - name: Write results
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() && !cancelled() && steps.docker-mirror-pull.conclusion == 'success' }}
         env:
           DOCKER_MIRROR_PULL_MEAN: ${{ steps.docker-mirror-pull.outputs.mean }}
           DOCKER_MIRROR_PULL_MIN: ${{ steps.docker-mirror-pull.outputs.min }}

--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -25,7 +25,8 @@ jobs:
         id: docker-mirror-pull
         run: |
           for ((i=0; i<3; i++)); do
-            docker rmi ubuntu:24.04 || true
+            docker rmi ubuntu:24.04 2>/dev/null || true
+            docker image prune -f
             /usr/bin/time -o temp_time.txt -f %e docker pull ubuntu:24.04
             cat temp_time.txt >> time.txt
             rm -f temp_time.txt
@@ -69,7 +70,7 @@ jobs:
           sudo apt install -y python3-venv
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install matplotlib pandas
+          pip install matplotlib pandas pytz
           echo '
           import datetime
           import os

--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -70,14 +70,13 @@ jobs:
           sudo apt install -y python3-venv
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install matplotlib pandas pytz
+          pip install matplotlib pandas
           echo '
           import datetime
           import os
 
           from matplotlib import pyplot as plt
           import pandas as pd
-          import pytz
 
           run_name = os.getenv("RUN_NAME")
 
@@ -86,7 +85,7 @@ jobs:
           my_data = my_data[
               my_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now().replace(tzinfo=pytz.UTC) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
               )
           ]
 

--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -26,15 +26,14 @@ jobs:
         run: |
           for ((i=0; i<3; i++)); do
             docker rmi ubuntu:24.04 2>/dev/null || true
-            docker image prune -f
+            docker image prune -a -f
+            docker builder prune -a -f
             /usr/bin/time -o temp_time.txt -f %e docker pull ubuntu:24.04
             cat temp_time.txt >> time.txt
             rm -f temp_time.txt
           done
           sleep 1
-          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'mean_time.txt').write_text(str(statistics.mean(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
-          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'min_time.txt').write_text(str(min(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
-          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'max_time.txt').write_text(str(max(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
+          python3 -c "import pathlib, statistics; base = pathlib.Path(); values = [float(line) for line in (base / 'time.txt').read_text().splitlines()]; (base / 'mean_time.txt').write_text(str(statistics.mean(values))); (base / 'min_time.txt').write_text(str(min(values))); (base / 'max_time.txt').write_text(str(max(values)))"
           cat mean_time.txt
           cat min_time.txt
           cat max_time.txt

--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -1,0 +1,121 @@
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        type: string
+        description: >-
+          JSON-encoded runner label(s). Use a JSON array for self-hosted runners,
+          e.g. '["self-hosted","amd64","self-hosted-linux-amd64-noble-large"]',
+          or a JSON string for GitHub-hosted, e.g. '"ubuntu-latest"'.
+      run-name:
+        type: string
+        description: Stem used for the CSV and PNG filenames on gh-pages, e.g. docker-mirror-ps7-amd64
+
+jobs:
+  run:
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+    env:
+      RUN_NAME: ${{ inputs.run-name }}
+    steps:
+      - run: sudo apt-get update
+        if: ${{ always() && !cancelled() }}
+
+      - name: Docker mirror pull test
+        if: ${{ always() && !cancelled() }}
+        id: docker-mirror-pull
+        run: |
+          for ((i=0; i<3; i++)); do
+            docker rmi ubuntu:24.04 || true
+            /usr/bin/time -o temp_time.txt -f %e docker pull ubuntu:24.04
+            cat temp_time.txt >> time.txt
+            rm -f temp_time.txt
+          done
+          sleep 1
+          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'mean_time.txt').write_text(str(statistics.mean(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
+          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'min_time.txt').write_text(str(min(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
+          python3 -c "import pathlib; import statistics; (pathlib.Path() / 'max_time.txt').write_text(str(max(map(float, (pathlib.Path() / 'time.txt').read_text().splitlines()))))"
+          cat mean_time.txt
+          cat min_time.txt
+          cat max_time.txt
+          echo "mean=$(cat mean_time.txt)" >> $GITHUB_OUTPUT
+          echo "min=$(cat min_time.txt)" >> $GITHUB_OUTPUT
+          echo "max=$(cat max_time.txt)" >> $GITHUB_OUTPUT
+          rm time.txt mean_time.txt min_time.txt max_time.txt
+
+      - name: Checkout GitHub pages
+        uses: actions/checkout@v6
+        if: ${{ always() && !cancelled() }}
+        with:
+          ref: gh-pages
+
+      - name: Prepare dir
+        if: ${{ always() && !cancelled() }}
+        run: |
+          mkdir -p results/v1/
+          test -f results/v1/$RUN_NAME.csv || echo "time,docker mirror pull mean (s),docker mirror pull min (s),docker mirror pull max (s)," > results/v1/$RUN_NAME.csv
+
+      - name: Write results
+        if: ${{ always() && !cancelled() }}
+        env:
+          DOCKER_MIRROR_PULL_MEAN: ${{ steps.docker-mirror-pull.outputs.mean }}
+          DOCKER_MIRROR_PULL_MIN: ${{ steps.docker-mirror-pull.outputs.min }}
+          DOCKER_MIRROR_PULL_MAX: ${{ steps.docker-mirror-pull.outputs.max }}
+        run: |
+          echo $(TZ=UTC date +"%Y-%m-%dT%H:%M:%S%z"),$DOCKER_MIRROR_PULL_MEAN,$DOCKER_MIRROR_PULL_MIN,$DOCKER_MIRROR_PULL_MAX, >> results/v1/$RUN_NAME.csv
+
+      - name: Create charts
+        if: ${{ always() && !cancelled() }}
+        run: |
+          sudo apt install -y python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install matplotlib pandas
+          echo '
+          import datetime
+          import os
+
+          from matplotlib import pyplot as plt
+          import pandas as pd
+          import pytz
+
+          run_name = os.getenv("RUN_NAME")
+
+          my_data = pd.read_csv(f"results/v1/{run_name}.csv")
+          my_data["time"] = pd.to_datetime(my_data["time"])
+          my_data = my_data[
+              my_data.time
+              >= pd.to_datetime(
+                  datetime.datetime.now().replace(tzinfo=pytz.UTC) - datetime.timedelta(days=7)
+              )
+          ]
+
+          plt.plot(my_data["time"], my_data["docker mirror pull max (s)"], label="max")
+          plt.plot(my_data["time"], my_data["docker mirror pull mean (s)"], label="mean")
+          plt.plot(my_data["time"], my_data["docker mirror pull min (s)"], label="min")
+          plt.legend()
+          plt.title("Docker Mirror Pull Time")
+          plt.xlabel("time")
+          plt.ylabel("seconds")
+          plt.xticks(rotation=30)
+
+          fig = plt.gcf()
+          fig.set_figwidth(1.5 * 16)
+          fig.set_figheight(1.5 * 9)
+          plt.savefig(f"results/v1/{run_name}.png")
+          ' > create_chart.py
+          python create_chart.py
+          deactivate
+          rm -rf .venv
+          rm create_chart.py
+
+      - name: Upload csv
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-csv', inputs.run-name) }}
+          path: ${{ format('results/v1/{0}.csv', inputs.run-name) }}
+
+      - name: Upload png
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-png', inputs.run-name) }}
+          path: ${{ format('results/v1/{0}.png', inputs.run-name) }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -95,13 +95,12 @@ jobs:
 
           from matplotlib import pyplot as plt
           import pandas as pd
-          import pytz
 
           run_name = os.getenv("RUN_NAME")
 
           my_data = pd.read_csv(f"results/v1/{run_name}.csv")
           my_data["time"] = pd.to_datetime(my_data["time"])
-          my_data = my_data[my_data.time >= pd.to_datetime(datetime.datetime.now().replace(tzinfo=pytz.UTC) - datetime.timedelta(days=7))]
+          my_data = my_data[my_data.time >= pd.to_datetime(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7))]
 
           plt.subplot(2, 3, 1)
           plt.plot(my_data["time"], my_data["network speed test ping (s)"])

--- a/.github/workflows/benchmarks-docker-mirror.yaml
+++ b/.github/workflows/benchmarks-docker-mirror.yaml
@@ -32,6 +32,7 @@ jobs:
 
   publish:
     runs-on: [self-hosted, amd64]
+    if: always()
     needs:
       - benchmark-ps6-arm64
       - benchmark-ps7-amd64
@@ -39,34 +40,42 @@ jobs:
       - benchmark-github-hosted
     steps:
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps6-arm64.result == 'success' }}
         with:
           name: docker-mirror-ps6-arm64-csv
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps6-arm64.result == 'success' }}
         with:
           name: docker-mirror-ps6-arm64-png
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps7-amd64.result == 'success' }}
         with:
           name: docker-mirror-ps7-amd64-csv
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps7-amd64.result == 'success' }}
         with:
           name: docker-mirror-ps7-amd64-png
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps7-arm64.result == 'success' }}
         with:
           name: docker-mirror-ps7-arm64-csv
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-ps7-arm64.result == 'success' }}
         with:
           name: docker-mirror-ps7-arm64-png
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-github-hosted.result == 'success' }}
         with:
           name: docker-mirror-github-hosted-csv
           path: results/v1/
       - uses: actions/download-artifact@v8
+        if: ${{ needs.benchmark-github-hosted.result == 'success' }}
         with:
           name: docker-mirror-github-hosted-png
           path: results/v1/

--- a/.github/workflows/benchmarks-docker-mirror.yaml
+++ b/.github/workflows/benchmarks-docker-mirror.yaml
@@ -1,0 +1,81 @@
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 */6 * * *"
+
+jobs:
+  benchmark-ps6-arm64:
+    uses: ./.github/workflows/benchmark-docker-mirror.yaml
+    with:
+      runs-on: '["self-hosted","arm64","self-hosted-linux-arm64-noble-large"]'
+      run-name: docker-mirror-ps6-arm64
+
+  benchmark-ps7-amd64:
+    uses: ./.github/workflows/benchmark-docker-mirror.yaml
+    with:
+      runs-on: '["self-hosted","amd64","self-hosted-linux-amd64-noble-large"]'
+      run-name: docker-mirror-ps7-amd64
+
+  benchmark-ps7-arm64:
+    uses: ./.github/workflows/benchmark-docker-mirror.yaml
+    with:
+      runs-on: '["self-hosted","arm64","self-hosted-linux-arm64-noble-large","reactive"]'
+      run-name: docker-mirror-ps7-arm64
+
+  benchmark-github-hosted:
+    uses: ./.github/workflows/benchmark-docker-mirror.yaml
+    with:
+      runs-on: '"ubuntu-latest"'
+      run-name: docker-mirror-github-hosted
+
+  publish:
+    runs-on: [self-hosted, amd64]
+    needs:
+      - benchmark-ps6-arm64
+      - benchmark-ps7-amd64
+      - benchmark-ps7-arm64
+      - benchmark-github-hosted
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps6-arm64-csv
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps6-arm64-png
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps7-amd64-csv
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps7-amd64-png
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps7-arm64-csv
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-ps7-arm64-png
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-github-hosted-csv
+          path: results/v1/
+      - uses: actions/download-artifact@v8
+        with:
+          name: docker-mirror-github-hosted-png
+          path: results/v1/
+      - run: ls -la results/v1/
+      - name: Publish
+        if: ${{ always() && !cancelled() }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          keep_files: true
+          enable_jekyll: true

--- a/.github/workflows/benchmarks-docker-mirror.yaml
+++ b/.github/workflows/benchmarks-docker-mirror.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: docker-mirror-github-hosted-png
           path: results/v1/
-      - run: ls -la results/v1/
+      - run: ls -la results/v1/ || echo "No results downloaded (all runners may be offline)"
       - name: Publish
         if: ${{ always() && !cancelled() }}
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -49,7 +49,6 @@ jobs:
           import datetime
 
           import pandas as pd
-          import pytz
           from matplotlib import pyplot as plt
 
           self_hosted_data = pd.read_csv("results/v1/self-hosted-amd.csv")
@@ -57,7 +56,7 @@ jobs:
           self_hosted_data = self_hosted_data[
               self_hosted_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now().replace(tzinfo=pytz.UTC) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
               )
           ]
 
@@ -66,7 +65,7 @@ jobs:
           github_hosted_data = github_hosted_data[
               github_hosted_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now().replace(tzinfo=pytz.UTC) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
               )
           ]
 


### PR DESCRIPTION
## Summary

Adds Docker registry mirror pull speed benchmarking to track the mirror/proxy bottleneck identified in PFEREQ-2.

## New workflows

- benchmark-docker-mirror.yaml: reusable workflow that cold-pulls ubuntu:24.04 3x through the daemon-configured DockerHub mirror, records mean/min/max pull time to gh-pages CSV, generates a chart PNG, and uploads both as artifacts.
- benchmarks-docker-mirror.yaml: orchestrator that runs the reusable workflow across PS6 arm64, PS7 amd64, PS7 arm64 (reactive), and GitHub-hosted (baseline), then publishes all results to gh-pages.

## Runner matrix

| run-name | Labels | Cloud |
|---|---|---|
| docker-mirror-ps6-arm64 | self-hosted, arm64, self-hosted-linux-arm64-noble-large | PS6 |
| docker-mirror-ps7-amd64 | self-hosted, amd64, self-hosted-linux-amd64-noble-large | PS7 |
| docker-mirror-ps7-arm64 | self-hosted, arm64, self-hosted-linux-arm64-noble-large, reactive | PS7 |
| docker-mirror-github-hosted | ubuntu-latest | GitHub (baseline) |

## Schedule

Every 6 hours (same as the existing benchmark), plus workflow_dispatch for on-demand runs.

## Key design choices

- docker image prune -a -f and docker builder prune -a -f between pulls for full cache eviction (cold-pull semantics, not just dangling image removal)
- Mean/min/max stats computed in a single Python invocation to avoid re-reading the file three times
- publish job uses if: always() at job level plus per-step guards on artifact downloads, so partial results are published even when individual runner pools are offline