### PR TITLE
feat: add Docker registry mirror results to the UI

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ always() && !cancelled() }}
         run: |
           mkdir -p results/v1/
-          test -f results/v1/$RUN_NAME.csv || echo "time,network speed test ping (s),jitter (s),upload (bit/s),download (bit/s),charmhub resource download mean (s),min (s),max (s)," > results/v1/$RUN_NAME.csv
+          test -f results/v1/$RUN_NAME.csv || echo "time,network speed test ping (s),jitter (ms),upload (bit/s),download (bit/s),charmhub resource download mean (s),min (s),max (s)," > results/v1/$RUN_NAME.csv
       - name: Write results
         if: ${{ always() && !cancelled() }}
         env:
@@ -99,6 +99,7 @@ jobs:
           run_name = os.getenv("RUN_NAME")
 
           my_data = pd.read_csv(f"results/v1/{run_name}.csv")
+          my_data = my_data.rename(columns={"jitter (s)": "jitter (ms)"})
           my_data["time"] = pd.to_datetime(my_data["time"])
           my_data = my_data[my_data.time >= pd.to_datetime(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7))]
 
@@ -110,7 +111,7 @@ jobs:
           plt.xticks(rotation=30)
 
           plt.subplot(2, 3, 2)
-          plt.plot(my_data["time"], my_data["jitter (s)"])
+          plt.plot(my_data["time"], my_data["jitter (ms)"])
           plt.title("Jitter")
           plt.xlabel("time")
           plt.ylabel("milliseconds")

--- a/.github/workflows/benchmarks-docker-mirror.yaml
+++ b/.github/workflows/benchmarks-docker-mirror.yaml
@@ -39,6 +39,12 @@ jobs:
       - benchmark-ps7-arm64
       - benchmark-github-hosted
     steps:
+      - name: Checkout index.md from main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          sparse-checkout: index.md
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@v8
         if: ${{ needs.benchmark-ps6-arm64.result == 'success' }}
         with:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -217,6 +217,12 @@ jobs:
       - benchmark-github-hosted
       - comparison
     steps:
+      - name: Checkout index.md from main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          sparse-checkout: index.md
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@v8
         with:
           name: self-hosted-arm-csv

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -52,6 +52,7 @@ jobs:
           from matplotlib import pyplot as plt
 
           self_hosted_data = pd.read_csv("results/v1/self-hosted-amd.csv")
+          self_hosted_data = self_hosted_data.rename(columns={"jitter (s)": "jitter (ms)"})
           self_hosted_data["time"] = pd.to_datetime(self_hosted_data["time"])
           self_hosted_data = self_hosted_data[
               self_hosted_data.time
@@ -61,6 +62,7 @@ jobs:
           ]
 
           github_hosted_data = pd.read_csv("results/v1/github-hosted.csv")
+          github_hosted_data = github_hosted_data.rename(columns={"jitter (s)": "jitter (ms)"})
           github_hosted_data["time"] = pd.to_datetime(self_hosted_data["time"])
           github_hosted_data = github_hosted_data[
               github_hosted_data.time
@@ -74,7 +76,7 @@ jobs:
           comparison_data[ping_column_name] = (
               comparison_data[ping_column_name] - github_hosted_data[ping_column_name]
           )
-          jitter_column_name = "jitter (s)"
+          jitter_column_name = "jitter (ms)"
           comparison_data[jitter_column_name] = (
               comparison_data[jitter_column_name] - github_hosted_data[jitter_column_name]
           )

--- a/index.md
+++ b/index.md
@@ -1,0 +1,93 @@
+# GitHub Runner Benchmark Results
+
+This page shows performance benchmarks comparing the GitHub and self-hosted runners.
+
+The tests run periodically throughout the day and test the networking performance. There are 2
+tests that are executed, a speedtest using
+[librespeed-cli](https://github.com/librespeed/speedtest-cli) and a download test of a resource
+from Charmhub.
+
+## Self vs GitHub Hosted Performance
+
+The following chart shows relative performance of the self-hosted versus GitHub hosted runners.
+Each point of the graph shows the relative performance of self versus GitHub hosted. For example,
+if a point is marked as zero, then for a given chart and point in time, the self and GitHub
+hosted runners performed the same. The differences are primarily driven by the underlying
+infrastructure each of the runners is hosted on.
+
+Each point on the graph is either red or green. If a point is red, it means that the self hosted
+runners performed worse and if a point is green, the self hosted runners performed better than the
+GitHub hosted runners. The values are computed by subtracting the GitHub hosted result from the
+self hosted result. For time based tests, such as the ping, jitter and Charmhub resource download
+tests, a positive value indicates the self hosted runners performed worse than the GitHub hosted
+runners. For speed based results, such as the download and upload tests, a negative value
+indicates the self hosted runners performed worse than the GitHub hosted runners.
+
+![Comparison](results/v1/comparison.png "Comparison")
+
+## Runner Type Results
+
+For each type of runner below, there are two rows of charts. The first row shows the speed test
+and the second row shows the Charmhub resource download result. Each point on the chart
+represents a result at a given time. All tests are point in time so not continuous.
+
+For the speedtest row, the first chart for the speedtest is the ping in milliseconds and the
+second chart shows the jitter also in milliseconds. The third chart shows the download and upload
+speed in MBit/s. These charts show the health of the networking.
+
+For the Charmhub resource download row, the chart shows the minimum, mean and maximum download
+time in seconds for a resource from Charmhub. This chart should be compared over time as
+variations in how long resources take to download has an impact on the consistency of job
+execution.
+
+### Self Hosted AMD64
+
+![Self Hosted AMD64](results/v1/self-hosted-amd.png "Self Hosted AMD64")
+
+[CSV results](results/v1/self-hosted-amd.csv)
+
+### Self Hosted ARM64
+
+![Self Hosted ARM64](results/v1/self-hosted-arm.png "Self Hosted ARM64")
+
+[CSV results](results/v1/self-hosted-arm.csv)
+
+### GitHub Hosted
+
+![GitHub Hosted](results/v1/github-hosted.png "GitHub Hosted")
+
+[CSV results](results/v1/github-hosted.csv)
+
+## Docker Registry Mirror Pull Speed
+
+The following benchmarks measure the time taken to pull the `ubuntu:24.04` image from the Docker
+registry mirror configured on each runner. The test pulls the image 3 times (clearing the local
+cache between each run) and records the minimum, mean, and maximum pull time in seconds. A lower
+value indicates faster access to the registry mirror.
+
+These benchmarks run on a separate schedule from the network benchmarks above and cover a
+different set of runner flavours.
+
+### ARM64 Noble Large (PS6)
+
+![ARM64 Noble Large (PS6)](results/v1/docker-mirror-ps6-arm64.png "ARM64 Noble Large (PS6)")
+
+[CSV results](results/v1/docker-mirror-ps6-arm64.csv)
+
+### AMD64 Noble Large (PS7)
+
+![AMD64 Noble Large (PS7)](results/v1/docker-mirror-ps7-amd64.png "AMD64 Noble Large (PS7)")
+
+[CSV results](results/v1/docker-mirror-ps7-amd64.csv)
+
+### ARM64 Noble Large Reactive (PS7)
+
+![ARM64 Noble Large Reactive (PS7)](results/v1/docker-mirror-ps7-arm64.png "ARM64 Noble Large Reactive (PS7)")
+
+[CSV results](results/v1/docker-mirror-ps7-arm64.csv)
+
+### GitHub Hosted
+
+![GitHub Hosted Docker](results/v1/docker-mirror-github-hosted.png "GitHub Hosted Docker")
+
+[CSV results](results/v1/docker-mirror-github-hosted.csv)

--- a/index.md
+++ b/index.md
@@ -2,10 +2,11 @@
 
 This page shows performance benchmarks comparing the GitHub and self-hosted runners.
 
-The tests run periodically throughout the day and test the networking performance. There are 2
-tests that are executed, a speedtest using
+The network benchmarks run periodically throughout the day and test networking performance. These
+benchmarks include a speedtest using
 [librespeed-cli](https://github.com/librespeed/speedtest-cli) and a download test of a resource
-from Charmhub.
+from Charmhub. This page also includes a separate Docker registry mirror pull benchmark section
+below.
 
 ## Self vs GitHub Hosted Performance
 
@@ -31,9 +32,9 @@ For each type of runner below, there are two rows of charts. The first row shows
 and the second row shows the Charmhub resource download result. Each point on the chart
 represents a result at a given time. All tests are point in time so not continuous.
 
-For the speedtest row, the first chart for the speedtest is the ping in milliseconds and the
-second chart shows the jitter also in milliseconds. The third chart shows the download and upload
-speed in MBit/s. These charts show the health of the networking.
+For the speedtest row, the first chart for the speedtest is the ping in seconds and the
+second chart shows the jitter also in seconds. The third chart shows the download and upload
+speed in bit/s. These charts show the health of the networking.
 
 For the Charmhub resource download row, the chart shows the minimum, mean and maximum download
 time in seconds for a resource from Charmhub. This chart should be compared over time as

--- a/index.md
+++ b/index.md
@@ -33,7 +33,7 @@ and the second row shows the Charmhub resource download result. Each point on th
 represents a result at a given time. All tests are point in time so not continuous.
 
 For the speedtest row, the first chart for the speedtest is the ping in seconds and the
-second chart shows the jitter also in seconds. The third chart shows the download and upload
+second chart shows the jitter in milliseconds. The third chart shows the download and upload
 speed in bit/s. These charts show the health of the networking.
 
 For the Charmhub resource download row, the chart shows the minimum, mean and maximum download


### PR DESCRIPTION
## Summary

Adds the Docker registry mirror pull speed benchmark results to the GitHub Pages UI.

### Problem
The Docker registry mirror benchmarks (added in #40) have been collecting data but the results were never displayed on the [benchmark UI](https://canonical.github.io/self-hosted-runner-performance-benchmark/).

### Changes

**`index.md`** (new file in `main`)
- Moved from `gh-pages` (where it was only preserved via `keep_files: true`) into `main` so UI changes go through normal PRs
- Adds a new **Docker Registry Mirror Pull Speed** section with charts and CSV links for all 4 runner flavours:
  - ARM64 Noble Large (PS6)
  - AMD64 Noble Large (PS7)
  - ARM64 Noble Large Reactive (PS7)
  - GitHub Hosted

**`.github/workflows/benchmarks.yaml`** and **`benchmarks-docker-mirror.yaml`**
- Both publish jobs now sparse-checkout `index.md` from `main` at the start, so the file is included in every `gh-pages` deployment going forward