### PR TITLE
fix: github hosted data reference

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -63,7 +63,7 @@ jobs:
 
           github_hosted_data = pd.read_csv("results/v1/github-hosted.csv")
           github_hosted_data = github_hosted_data.rename(columns={"jitter (s)": "jitter (ms)"})
-          github_hosted_data["time"] = pd.to_datetime(self_hosted_data["time"])
+          github_hosted_data["time"] = pd.to_datetime(github_hosted_data["time"])
           github_hosted_data = github_hosted_data[
               github_hosted_data.time
               >= pd.to_datetime(


### PR DESCRIPTION
The data flatlined is due to the issue that this PR fixes which references wrong data.

<img width="2400" height="1350" alt="image" src="https://github.com/user-attachments/assets/1756e2c3-afeb-4860-8cac-374635397098" />
