### PR TITLE
fix: use github_hosted_data time when parsing comparison chart times

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -63,7 +63,7 @@ jobs:
 
           github_hosted_data = pd.read_csv("results/v1/github-hosted.csv")
           github_hosted_data = github_hosted_data.rename(columns={"jitter (s)": "jitter (ms)"})
-          github_hosted_data["time"] = pd.to_datetime(self_hosted_data["time"])
+          github_hosted_data["time"] = pd.to_datetime(github_hosted_data["time"])
           github_hosted_data = github_hosted_data[
               github_hosted_data.time
               >= pd.to_datetime(


### PR DESCRIPTION
## Problem

The comparison chart in the Self vs GitHub Hosted Performance section was flat for all 7 charts. Only the horizontal `axhline(y=0)` was visible with no data points.

## Root Cause

In the `comparison` job's Python script, `github_hosted_data["time"]` was incorrectly assigned from `self_hosted_data["time"]`:

```python
# Before (bug)
github_hosted_data["time"] = pd.to_datetime(self_hosted_data["time"])
```

Since the two CSVs have different row counts (e.g. 2534 vs 2506 rows currently), after the 7-day filter each DataFrame ends up with a different pandas index. When subtracting column values (e.g. `self_hosted - github_hosted`), pandas aligns by index — mismatched indices produce `NaN` for every row, so no scatter points render.

## Fix

```python
# After (fix)
github_hosted_data["time"] = pd.to_datetime(github_hosted_data["time"])
```

## Verification

Charts were generated locally using the live CSV data. All 7 subplots now show red/green data points as intended.