### PR TITLE
chore: increase time from a week to a month

### DIFF
--- a/.github/workflows/benchmark-docker-mirror.yaml
+++ b/.github/workflows/benchmark-docker-mirror.yaml
@@ -84,7 +84,7 @@ jobs:
           my_data = my_data[
               my_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
               )
           ]
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -101,7 +101,7 @@ jobs:
           my_data = pd.read_csv(f"results/v1/{run_name}.csv")
           my_data = my_data.rename(columns={"jitter (s)": "jitter (ms)"})
           my_data["time"] = pd.to_datetime(my_data["time"])
-          my_data = my_data[my_data.time >= pd.to_datetime(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7))]
+          my_data = my_data[my_data.time >= pd.to_datetime(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30))]
 
           plt.subplot(2, 3, 1)
           plt.plot(my_data["time"], my_data["network speed test ping (s)"])

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -57,7 +57,7 @@ jobs:
           self_hosted_data = self_hosted_data[
               self_hosted_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
               )
           ]
 
@@ -67,7 +67,7 @@ jobs:
           github_hosted_data = github_hosted_data[
               github_hosted_data.time
               >= pd.to_datetime(
-                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
+                  datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
               )
           ]
 


### PR DESCRIPTION
Increase duration of the graphs from a week to a month for better trend viewing (a week is not enough to view trends, especially with outages)